### PR TITLE
Add Dockerfile and basic CLI module for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --upgrade pip && pip install .
+
+CMD ["python", "-m", "src.newsletter_bot"]

--- a/src/newsletter_bot.py
+++ b/src/newsletter_bot.py
@@ -1,0 +1,12 @@
+"""Command line interface for newsletter bot."""
+
+import click
+
+
+@click.group()
+def cli() -> None:
+    """Entry point for the newsletter bot CLI."""
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add a minimal Dockerfile so CI can build the project image
- introduce a basic `newsletter_bot` CLI module for import tests

## Testing
- `flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: command not found)*
- `black --check src/`
- `isort --check-only src/ -v`
- `mypy src/`
- `pytest tests/ -v`
- `docker build -t newsletter-bot:test .` *(fails: command not found)*
- `docker run --rm newsletter-bot:test python -c "import src.newsletter_bot; print('Import successful')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68977cc7c2c883268e0d920c4bd4d696