### PR TITLE
chore: upgrade CodeQL upload action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         output: 'trivy-results.sarif'
     
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- use CodeQL Action v3 when uploading Trivy scan results

## Testing
- `pip install -e ".[dev]"` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689780e32ed88326a48acb96ce778062