### PR TITLE
Grant security-events permission for SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
## Summary
- fix permissions in security workflow so SARIF upload works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68978dce380c8326b32935660a6ce12e