### PR TITLE
Add Curated Briefing checker CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
+        pip install -r requirements.txt
     
     - name: Lint with flake8
       run: |
@@ -52,6 +53,9 @@ jobs:
         BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
         OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         UNSPLASH_API_KEY: ${{ secrets.UNSPLASH_API_KEY }}
+
+    - name: Lint sample briefing
+      run: python check_briefing.py tests/fixtures/good_briefing.html
     
     - name: Build Docker image
       run: docker build -t newsletter-bot:test .
@@ -79,6 +83,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
+        pip install -r requirements.txt
     
     - name: Run health check
       run: python -m src.newsletter_bot health

--- a/check_briefing.py
+++ b/check_briefing.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class ParsedDocument:
+    source: str
+    text: str
+    headings: List[Tuple[int, str]]
+    raw_headings: List[str]
+    anchors: List[Tuple[str, str]]
+    images: List[Tuple[str, Optional[str]]]
+
+
+@dataclass
+class RuleResult:
+    name: str
+    passed: bool
+    count: int
+    examples: List[str]
+
+
+def normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def parse_html(content: str, source: str) -> ParsedDocument:
+    soup = BeautifulSoup(content, "lxml")
+    container = soup.find("main") or soup.find("article") or soup.find("body") or soup
+    text = normalize_whitespace(container.get_text(" "))
+
+    headings: List[Tuple[int, str]] = []
+    raw_headings: List[str] = []
+    for level in range(1, 7):
+        for tag in container.find_all(f"h{level}"):
+            raw = tag.get_text(" ")
+            raw_headings.append(raw)
+            headings.append((level, normalize_whitespace(raw)))
+
+    anchors: List[Tuple[str, str]] = []
+    for a in container.find_all("a"):
+        href = a.get("href", "")
+        anchors.append((href, normalize_whitespace(a.get_text(" "))))
+
+    images: List[Tuple[str, Optional[str]]] = []
+    for img in container.find_all("img"):
+        src = img.get("src", "")
+        alt = img.get("alt")
+        images.append((src, normalize_whitespace(alt) if alt is not None else None))
+
+    return ParsedDocument(
+        source=source,
+        text=text,
+        headings=headings,
+        raw_headings=raw_headings,
+        anchors=anchors,
+        images=images,
+    )
+
+
+def parse_md(content: str, source: str) -> ParsedDocument:
+    headings: List[Tuple[int, str]] = []
+    raw_headings: List[str] = []
+    anchors: List[Tuple[str, str]] = []
+    images: List[Tuple[str, Optional[str]]] = []
+    text_lines: List[str] = []
+
+    for line in content.splitlines():
+        heading_match = re.match(r"^(#{1,6})\s+(.*)", line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            raw = heading_match.group(2)
+            heading_text = normalize_whitespace(raw)
+            headings.append((level, heading_text))
+            raw_headings.append(raw)
+            text_lines.append(heading_text)
+            continue
+
+        def replace_image(match: re.Match) -> str:
+            alt, src = match.group(1), match.group(2)
+            images.append((src, normalize_whitespace(alt)))
+            return alt
+
+        line = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", replace_image, line)
+
+        def replace_link(match: re.Match) -> str:
+            text, href = match.group(1), match.group(2)
+            anchors.append((href, normalize_whitespace(text)))
+            return text
+
+        line = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", replace_link, line)
+        text_lines.append(line)
+
+    text = normalize_whitespace(" ".join(text_lines))
+    return ParsedDocument(
+        source=source,
+        text=text,
+        headings=headings,
+        raw_headings=raw_headings,
+        anchors=anchors,
+        images=images,
+    )
+
+
+class BriefingChecker:
+    def __init__(self, golden: Optional[ParsedDocument] = None) -> None:
+        self.golden = golden
+        self.rules: List[Callable[[ParsedDocument], RuleResult]] = [
+            self.rule_prompt_leakage,
+            self.rule_guardrail_refusals,
+            self.rule_raw_urls_in_copy,
+            self.rule_non_canonical_links,
+            self.rule_generic_or_placeholder_link_text,
+            self.rule_headline_style_inconsistencies,
+            self.rule_separators_and_spacing,
+            self.rule_image_alt_captions,
+            self.rule_truncated_or_unbalanced_sentences,
+        ]
+        if golden is not None:
+            self.rules.append(self.rule_section_parity_with_golden)
+
+    # Rule implementations
+    def rule_prompt_leakage(self, doc: ParsedDocument) -> RuleResult:
+        patterns = [
+            r"hint to ai",
+            r"system prompt",
+            r"\buser:\b",
+            r"\bassistant:\b",
+            r"as an ai language model",
+            r"do not (?:include|output|mention)",
+        ]
+        matches: List[str] = []
+        for pat in patterns:
+            for m in re.finditer(pat, doc.text, re.IGNORECASE):
+                snippet = doc.text[max(0, m.start() - 20) : m.end() + 20]
+                matches.append(snippet.strip())
+        return RuleResult("prompt_leakage", not matches, len(matches), matches[:5])
+
+    def rule_guardrail_refusals(self, doc: ParsedDocument) -> RuleResult:
+        patterns = [
+            r"i['’]m sorry, but i can[’']t",
+            r"i cannot comply",
+            r"i can['’]t provide[^.]*?(illegal|harmful|dangerous|weapons|self-harm|malware)",
+        ]
+        matches: List[str] = []
+        for pat in patterns:
+            for m in re.finditer(pat, doc.text, re.IGNORECASE):
+                snippet = doc.text[max(0, m.start() - 20) : m.end() + 20]
+                matches.append(snippet.strip())
+        return RuleResult("guardrail_refusals", not matches, len(matches), matches[:5])
+
+    def rule_raw_urls_in_copy(self, doc: ParsedDocument) -> RuleResult:
+        url_pattern = re.compile(r"https?://\S+", re.IGNORECASE)
+        matches = [m.group(0) for m in url_pattern.finditer(doc.text)]
+        for _, text in doc.anchors:
+            if url_pattern.fullmatch(text):
+                if text not in matches:
+                    matches.append(text)
+        return RuleResult("raw_urls_in_copy", not matches, len(matches), matches[:5])
+
+    def rule_non_canonical_links(self, doc: ParsedDocument) -> RuleResult:
+        bad_hosts = {"feedbinusercontent.com", "substackcdn.com", "cdn.substack.com"}
+        matches: List[str] = []
+        for href, _ in doc.anchors:
+            host = urlparse(href).hostname or ""
+            if any(host.endswith(bad) for bad in bad_hosts):
+                matches.append(href)
+        return RuleResult("non_canonical_links", not matches, len(matches), matches[:5])
+
+    def rule_generic_or_placeholder_link_text(self, doc: ParsedDocument) -> RuleResult:
+        generic = {
+            "link",
+            "source",
+            "read more",
+            "article",
+            "newsletters",
+            "url",
+            "url1",
+            "url2",
+            "url3",
+            "visit",
+            "here",
+            "click here",
+        }
+        matches: List[str] = []
+        for _, text in doc.anchors:
+            t = text.strip().lower()
+            if t in generic or re.fullmatch(r"url\d+", t):
+                matches.append(text)
+        return RuleResult(
+            "generic_or_placeholder_link_text", not matches, len(matches), matches[:5]
+        )
+
+    def rule_headline_style_inconsistencies(self, doc: ParsedDocument) -> RuleResult:
+        matches: List[str] = []
+        for _, text in doc.headings:
+            letters = "".join(ch for ch in text if ch.isalpha())
+            if letters and letters.islower():
+                matches.append(text)
+                continue
+            if len(text.split()) <= 2 and len(text.replace(" ", "")) < 10:
+                matches.append(text)
+        return RuleResult(
+            "headline_style_inconsistencies", not matches, len(matches), matches[:5]
+        )
+
+    def rule_separators_and_spacing(self, doc: ParsedDocument) -> RuleResult:
+        matches: List[str] = []
+        for m in re.finditer(r"(\*\s*){3,}", doc.text):
+            matches.append(m.group(0))
+        for raw in doc.raw_headings:
+            if "  " in raw:
+                matches.append(raw)
+        return RuleResult("separators_and_spacing", not matches, len(matches), matches[:5])
+
+    def rule_image_alt_captions(self, doc: ParsedDocument) -> RuleResult:
+        generic = {"image", "photo", "picture", "graphic"}
+        matches: List[str] = []
+        for src, alt in doc.images:
+            if not alt or len(alt) < 5 or alt.lower() in generic:
+                matches.append(src or alt or "<missing>")
+        return RuleResult("image_alt_captions", not matches, len(matches), matches[:5])
+
+    def rule_truncated_or_unbalanced_sentences(self, doc: ParsedDocument) -> RuleResult:
+        sentences = re.split(r"(?<=[.!?])\s+", doc.text)
+        matches: List[str] = []
+        for s in sentences:
+            s = s.strip()
+            if not s:
+                continue
+            if len(s) > 60 and not re.search(r"""[.!?]['")\]]?$""", s):
+                matches.append(s[:80])
+        if doc.text.count("(") != doc.text.count(")"):
+            matches.append("unbalanced parentheses")
+        if doc.text.count("“") != doc.text.count("”"):
+            matches.append("unbalanced quotes")
+        if doc.text.count('"') % 2 != 0:
+            matches.append("unbalanced quotes")
+        return RuleResult(
+            "truncated_or_unbalanced_sentences", not matches, len(matches), matches[:5]
+        )
+
+    def rule_section_parity_with_golden(self, doc: ParsedDocument) -> RuleResult:
+        if not self.golden:
+            return RuleResult("section_parity_with_golden", True, 0, [])
+        golden_set = {
+            text.lower() for level, text in self.golden.headings if level in (2, 3)
+        }
+        doc_set = {text.lower() for level, text in doc.headings if level in (2, 3)}
+        missing = sorted(golden_set - doc_set)
+        extra = sorted(doc_set - golden_set)
+        examples: List[str] = []
+        for m in missing:
+            examples.append(f"missing: {m}")
+        for e in extra:
+            examples.append(f"extra: {e}")
+        count = len(missing) + len(extra)
+        return RuleResult(
+            "section_parity_with_golden", count == 0, count, examples[:5]
+        )
+
+    def check(self, doc: ParsedDocument) -> Tuple[bool, List[RuleResult]]:
+        results = [rule(doc) for rule in self.rules]
+        passed = all(r.passed for r in results)
+        return passed, results
+
+
+def load_source(source: str) -> ParsedDocument:
+    if re.match(r"https?://", source):
+        resp = requests.get(source, timeout=30)
+        resp.raise_for_status()
+        return parse_html(resp.text, source)
+
+    path = Path(source)
+    content = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".md", ".markdown"}:
+        return parse_md(content, source)
+    return parse_html(content, source)
+
+
+def print_report(source: str, passed: bool, results: List[RuleResult]) -> None:
+    print(f"Source: {source}")
+    print(f"Overall: {'PASS' if passed else 'FAIL'}")
+    header = f"{'Rule':40} {'Result':7} {'Count':5}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        print(f"{r.name:40} {'OK' if r.passed else 'FAIL':7} {r.count:5}")
+    for r in results:
+        if not r.passed and r.examples:
+            print(f"\nExamples for {r.name}:")
+            for ex in r.examples[:5]:
+                print(f"- {ex}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lint-check Curated Briefing newsletters")
+    parser.add_argument("inputs", nargs="+", help="URLs or local HTML/MD files")
+    parser.add_argument("--golden", help="URL or file of known good briefing")
+    parser.add_argument("--json", dest="json_path", help="Path to save JSON report")
+    args = parser.parse_args()
+
+    golden_doc: Optional[ParsedDocument] = None
+    if args.golden:
+        try:
+            golden_doc = load_source(args.golden)
+        except Exception as e:  # noqa: BLE001
+            parser.error(f"Failed to load golden source: {e}")
+
+    checker = BriefingChecker(golden_doc)
+    reports = []
+    for src in args.inputs:
+        try:
+            doc = load_source(src)
+            passed, results = checker.check(doc)
+            print_report(src, passed, results)
+            reports.append(
+                {
+                    "source": src,
+                    "passed": passed,
+                    "results": [r.__dict__ for r in results],
+                    "summary": {
+                        r.name: {"pass": r.passed, "count": r.count} for r in results
+                    },
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"Error processing {src}: {e}")
+
+    if args.json_path:
+        with open(args.json_path, "w", encoding="utf-8") as f:
+            json.dump({"reports": reports}, f, indent=2)
+
+    if not all(r["passed"] for r in reports):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/check_briefing.md
+++ b/docs/check_briefing.md
@@ -1,0 +1,44 @@
+# Curated Briefing Checker
+
+A small CLI tool to lint-check "Curated Briefing" newsletters before publishing.
+
+## Quick Start
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python check_briefing.py --golden GOLDEN_URL_OR_FILE newsletter.html
+```
+
+## Rules
+
+1. **prompt_leakage** – prompts or role tags like `user:` or `assistant:`.
+2. **guardrail_refusals** – boilerplate refusals such as "I'm sorry, but I can't...".
+3. **raw_urls_in_copy** – bare URLs or links whose text is a URL.
+4. **non_canonical_links** – links to `feedbinusercontent.com`, `substackcdn.com`, `cdn.substack.com`.
+5. **generic_or_placeholder_link_text** – anchors with text like `click here` or `source`.
+6. **headline_style_inconsistencies** – lowercase or overly short headings.
+7. **separators_and_spacing** – repeated separators (`***`) or headings with double spaces.
+8. **image_alt_captions** – missing, short, or generic image alt text.
+9. **truncated_or_unbalanced_sentences** – long sentences without terminal punctuation or unbalanced quotes/parentheses.
+10. **section_parity_with_golden** – h2/h3 differences compared to a golden briefing.
+
+## Example
+
+```bash
+python check_briefing.py --golden https://buttondown.com/filter/archive/curated-briefing-001 \
+    https://buttondown.com/filter/archive/curated-briefing-026/ \
+    --json report.json
+```
+
+## CI Tip
+
+Add a job to your GitHub Actions workflow:
+
+```yaml
+- name: Lint Curated Briefing
+  run: |
+    pip install -r requirements.txt
+    python check_briefing.py --golden $GOLDEN_URL path/to/briefing.html
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+lxml
+pyyaml

--- a/tests/fixtures/good_briefing.html
+++ b/tests/fixtures/good_briefing.html
@@ -1,0 +1,6 @@
+<main>
+  <h2>Good Section</h2>
+  <p>This is a proper sentence.</p>
+  <p><a href="https://example.com">Example link</a></p>
+  <img src="example.jpg" alt="An illustrative example image">
+</main>

--- a/tests/test_check_briefing.py
+++ b/tests/test_check_briefing.py
@@ -1,0 +1,100 @@
+import pytest
+
+from check_briefing import (
+    BriefingChecker,
+    ParsedDocument,
+    parse_html,
+    parse_md,
+)
+
+
+def test_prompt_leakage():
+    html = "<main>System prompt: do not include</main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_prompt_leakage(doc)
+    assert not result.passed
+    assert result.count >= 1
+
+
+def test_guardrail_refusals():
+    html = "<main>I'm sorry, but I can't help with that.</main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_guardrail_refusals(doc)
+    assert not result.passed
+    assert result.count == 1
+
+
+def test_raw_urls_in_copy():
+    html = "<main>Visit http://example.com for info</main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_raw_urls_in_copy(doc)
+    assert not result.passed
+    assert result.count == 1
+
+
+def test_non_canonical_links():
+    html = "<main><a href='https://feedbinusercontent.com/x'>bad</a></main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_non_canonical_links(doc)
+    assert not result.passed
+    assert result.count == 1
+
+
+def test_generic_or_placeholder_link_text():
+    html = "<main><a href='https://example.com'>Click here</a></main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_generic_or_placeholder_link_text(doc)
+    assert not result.passed
+    assert result.count == 1
+
+
+def test_headline_style_inconsistencies_markdown():
+    md = "## all lowercase heading\n## short"
+    doc = parse_md(md, "src")
+    checker = BriefingChecker()
+    result = checker.rule_headline_style_inconsistencies(doc)
+    assert not result.passed
+    assert result.count == 2
+
+
+def test_separators_and_spacing():
+    html = "<main>***<h2>Bad  heading</h2></main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_separators_and_spacing(doc)
+    assert not result.passed
+    assert result.count == 2
+
+
+def test_image_alt_captions():
+    html = "<main><img src='x.jpg' alt='image'></main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_image_alt_captions(doc)
+    assert not result.passed
+    assert result.count == 1
+
+
+def test_truncated_or_unbalanced_sentences():
+    html = "<main>This is a very long sentence that goes on and on without proper ending and should be flagged \"quote</main>"
+    doc = parse_html(html, "src")
+    checker = BriefingChecker()
+    result = checker.rule_truncated_or_unbalanced_sentences(doc)
+    assert not result.passed
+    assert result.count >= 1
+
+
+def test_section_parity_with_golden():
+    golden_html = "<main><h2>Alpha</h2><h3>Beta</h3></main>"
+    doc_html = "<main><h2>Alpha</h2><h3>Gamma</h3></main>"
+    golden = parse_html(golden_html, "golden")
+    doc = parse_html(doc_html, "doc")
+    checker = BriefingChecker(golden)
+    result = checker.rule_section_parity_with_golden(doc)
+    assert not result.passed
+    assert result.count == 2


### PR DESCRIPTION
## Summary
- add `check_briefing.py` CLI to lint Curated Briefing newsletters
- document rules and usage
- run briefing checker in CI and install requirements

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_check_briefing.py -q`
- `python check_briefing.py tests/fixtures/good_briefing.html`


------
https://chatgpt.com/codex/tasks/task_b_689a55697640832685ada9d851c72736