### PR TITLE
Refactor RSS utilities for clarity and add tests

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,0 +1,79 @@
+"""Utility functions for URL and text processing."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+
+def extract_source_from_url(url: str) -> str:
+    """Extract a human friendly source name from a URL.
+
+    Removes common subdomains and TLDs, applies known mappings and
+    returns a title-cased domain name. Returns an empty string if the
+    URL cannot be parsed.
+    """
+    if not url:
+        return ""
+
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+        if not domain:
+            return ""
+
+        domain = re.sub(r"^(www\.|m\.|mobile\.)", "", domain)
+        original_domain = domain
+        domain = re.sub(r"\.(com|org|net|edu|gov|io|co\.uk|ai)$", "", domain)
+
+        source_mapping = {
+            "nature": "Nature",
+            "techcrunch": "TechCrunch",
+            "arstechnica": "Ars Technica",
+            "wired": "WIRED",
+            "theverge": "The Verge",
+            "medium": "Medium",
+            "github": "GitHub",
+            "stackoverflow": "Stack Overflow",
+            "reddit": "Reddit",
+            "youtube": "YouTube",
+            "twitter": "Twitter",
+            "linkedin": "LinkedIn",
+            "openai": "OpenAI",
+            "anthropic": "Anthropic",
+            "google": "Google",
+            "microsoft": "Microsoft",
+            "apple": "Apple",
+            "meta": "Meta",
+        }
+
+        if domain in source_mapping:
+            return source_mapping[domain]
+
+        if ".substack" in original_domain:
+            subdomain = original_domain.split(".")[0]
+            return f"{subdomain.title()} (Substack)"
+
+        parts = domain.split(".")
+        if parts:
+            main_domain = parts[0]
+            return main_domain.replace("-", " ").replace("_", " ").title()
+
+        return domain.title()
+    except Exception:
+        return ""
+
+
+def clean_article_title(title: str) -> str:
+    """Clean article titles by removing noisy prefixes and extra whitespace."""
+    if not title:
+        return "Untitled Article"
+
+    cleaned = re.sub(r"^\[.*?\]\s*", "", title)
+    cleaned = re.sub(r"^(Fwd:|Re:|FW:)\s*", "", cleaned, flags=re.IGNORECASE)
+    cleaned = " ".join(cleaned.split())
+
+    if len(cleaned) < 5 or any(g in cleaned.lower() for g in ["untitled", "no subject", "fwd", "firehose"]):
+        return "Article Commentary"
+
+    return cleaned.strip()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,30 @@
+import pytest
+
+from src.core.utils import clean_article_title, extract_source_from_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://www.example.com/article", "Example"),
+        ("https://alice.substack.com/p/post", "Alice (Substack)"),
+        ("https://openai.com/blog", "OpenAI"),
+        ("https://blog.example.co.uk/story", "Blog"),
+        ("", ""),
+    ],
+)
+def test_extract_source_from_url(url, expected):
+    assert extract_source_from_url(url) == expected
+
+
+def test_clean_article_title_removes_noise():
+    title = "[Firehose] Fwd:  Hello World"
+    assert clean_article_title(title) == "Hello World"
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [("", "Untitled Article"), ("untitled", "Article Commentary"),],
+)
+def test_clean_article_title_edge_cases(title, expected):
+    assert clean_article_title(title) == expected


### PR DESCRIPTION
## Summary
- move source extraction and title cleaning logic into shared utilities
- update RSS client to use new helpers
- cover utilities with tests

## Testing
- `pytest tests/test_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'infisical_sdk')*

------
https://chatgpt.com/codex/tasks/task_b_689a5bfe4b5083269e10aa636d6b3d6f