### PR TITLE
Expand sanitizer AI refusal patterns

### DIFF
--- a/src/core/sanitizer.py
+++ b/src/core/sanitizer.py
@@ -26,6 +26,7 @@ class ContentSanitizer:
         r"I cannot assist with",
         r"I'm unable to help",
         r"I can't help with",
+        r"I can't provide assistance",
         r"I don't have the ability to",
     ]
 

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,0 +1,10 @@
+from src.core.sanitizer import ContentSanitizer
+
+
+def test_sanitizer_removes_ai_refusal_phrase():
+    sanitizer = ContentSanitizer()
+    text, issues = sanitizer.sanitize_text(
+        "I can't provide assistance with creating content that contains or promotes harmful, illegal, or adult material."
+    )
+    assert text == ""
+    assert any("AI refusal" in issue for issue in issues)


### PR DESCRIPTION
## Summary
- add explicit pattern for "I can't provide assistance" to sanitize guardrail refusals
- test sanitizer removes the new refusal phrase

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'infisical_sdk')*
- `pytest tests/test_sanitizer.py`


------
https://chatgpt.com/codex/tasks/task_b_689a5e79a7188326b5b9f30c7c54adb1