### PR TITLE
Handle optional deps lazily in CLI and secrets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ line_length = 88
 max-line-length = 88
 extend-ignore = ["E203", "W503", "E501"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/src/core/secrets.py
+++ b/src/core/secrets.py
@@ -3,7 +3,21 @@
 import logging
 from typing import Dict, Optional
 
-from infisical_sdk import InfisicalSDKClient  # type: ignore
+# The official Infisical SDK is optional. Import it lazily and provide a
+# tiny fallback so that the rest of the code (and tests) can run without
+# the package being installed.
+try:  # pragma: no cover - behaviour is trivial
+    from infisical_sdk import InfisicalSDKClient  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - only used in tests
+    class InfisicalSDKClient:  # type: ignore
+        """Fallback Infisical client used when the real SDK is unavailable.
+
+        The test suite replaces this placeholder with a mock, allowing the
+        rest of the module to be imported without the external dependency.
+        """
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+            pass
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/src/newsletter_bot.py
+++ b/src/newsletter_bot.py
@@ -5,8 +5,11 @@ import logging
 
 import click
 
-from src.core.newsletter import NewsletterGenerator
-from src.models.settings import Settings
+# Import heavy dependencies lazily within command functions to avoid
+# requiring optional packages (like pydantic and aiohttp) just to load
+# the CLI module.  This keeps ``cli`` importable in environments where
+# the full runtime dependencies aren't installed – for example during
+# basic tests that only check command registration.
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +39,11 @@ def generate(ctx: click.Context, dry_run: bool) -> None:
 
     async def _generate():
         try:
+            # Lazy imports to avoid importing heavy dependencies when the
+            # CLI module is merely imported (e.g. during tests).
+            from src.models.settings import Settings
+            from src.core.newsletter import NewsletterGenerator
+
             settings = Settings(debug=ctx.obj.get("debug", False))
             logger.info("Starting newsletter generation...")
 
@@ -190,6 +198,11 @@ def generate(ctx: click.Context, dry_run: bool) -> None:
 def health() -> None:
     """Check system health and configuration."""
     try:
+        # Import Settings lazily to avoid requiring optional dependencies
+        # when merely importing the CLI module.
+        from src.models.settings import Settings
+        from src.core.newsletter import NewsletterGenerator
+
         settings = Settings()
         logger.info("🔍 Checking system health...")
 


### PR DESCRIPTION
## Summary
- Load heavy dependencies lazily in `src.newsletter_bot` so the CLI can be imported without optional packages
- Provide a lightweight `InfisicalSDKClient` fallback when the Infisical SDK isn't installed
- Configure pytest to only collect tests under `tests/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a63303e1c832688f65230ba013e13