### PR TITLE
Fix flake8 lint violations

### DIFF
--- a/src/clients/readwise.py
+++ b/src/clients/readwise.py
@@ -317,7 +317,6 @@ class ReadwiseClient:
         curated = []
 
         for doc in documents:
-            reading_progress = doc.get("reading_progress", 0)
             tags = doc.get("tags", {})
 
             has_twiar_tag = self._has_twiar_tag(tags)

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, Optional, Tuple
 import aiohttp
 from pydantic import BaseModel
 
-
 from ..models.content import ContentItem
 
 logger = logging.getLogger(__name__)

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -12,20 +12,13 @@ import json
 import logging
 import os
 import sqlite3
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
 from pydantic import BaseModel
 
-try:
-    import redis.asyncio as redis
-
-    REDIS_AVAILABLE = True
-except ImportError:
-    REDIS_AVAILABLE = False
 
 from ..models.content import ContentItem
 

--- a/src/core/newsletter.py
+++ b/src/core/newsletter.py
@@ -295,7 +295,6 @@ Write the intro:"""
         out.append("\n---\n")
 
         # LEAD STORIES - MUST be 2-column table format
-        available_categories = [cat for cat, items in categories.items() if items]
 
         # Get top stories for lead section (limit to 2 for side-by-side)
         lead_stories = []
@@ -2836,14 +2835,15 @@ SPECIFIC REQUIREMENTS:
                     logger.warning(f"Failed to fetch article content for: {item.url}")
 
             # Step 2: Generate voice-based commentary using article + user highlights
+            voice_name = self.settings.default_voice.title()
+            preview_title = title[:50]
             logger.info(
-                f"🎭 {self.settings.default_voice.title()} voice: generating commentary for '{title[:50]}...'"
+                "🎭 %s voice: generating commentary for '%s...'",
+                voice_name,
+                preview_title,
             )
 
             # Prepare content for voice generation
-            content_for_voice = f"TITLE: {title}\n\nCONTENT: {article_content if article_content else 'Article content not available'}"
-            notes_for_voice = f"USER HIGHLIGHTS: {user_highlights}"
-
             try:
                 # Generate using clean OpenRouter commentary (bypassing contaminated voice templates)
                 commentary = await self.openrouter_client.generate_commentary(
@@ -2856,7 +2856,7 @@ SPECIFIC REQUIREMENTS:
                     title,
                 )
 
-                logger.debug(f"Generated clean commentary using OpenRouter client")
+                logger.debug("Generated clean commentary using OpenRouter client")
 
             except Exception as e:
                 logger.warning(f"Commentary generation failed: {e}")
@@ -3256,8 +3256,6 @@ SPECIFIC REQUIREMENTS:
         try:
             from urllib.parse import quote
 
-            import aiohttp
-
             # Strategy 1: Try full title search first (most precise)
             # Clean up the title but keep it mostly intact
             clean_title = title.strip()
@@ -3279,8 +3277,6 @@ SPECIFIC REQUIREMENTS:
                     return search_url
 
             # Strategy 2: Fallback to keyword extraction if full title search fails
-            import re
-
             # Remove common words and punctuation, keep meaningful terms
             search_terms = re.sub(r"[^\w\s]", " ", title.lower())
             words = search_terms.split()

--- a/src/core/readwise_cache.py
+++ b/src/core/readwise_cache.py
@@ -5,9 +5,7 @@ Caches 'twiar-tagged' documents for 1 hour to avoid repeated API calls.
 
 import json
 import logging
-import os
 import sqlite3
-import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/src/core/source_extractor.py
+++ b/src/core/source_extractor.py
@@ -314,7 +314,6 @@ async def resolve_newsletter_sources(
 
 # Example usage and testing
 if __name__ == "__main__":
-    import asyncio
 
     async def test_extractor():
         """Test the source extractor with known examples."""

--- a/src/core/voice_manager.py
+++ b/src/core/voice_manager.py
@@ -1,11 +1,9 @@
 """Voice management system for newsletter commentary generation."""
 
-import json
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .voices import AVAILABLE_VOICES, get_voice, list_voices
+from .voices import get_voice, list_voices
 from .voices.base import SaintVoiceGenerator, VoiceConfig, VoiceGenerator
 
 logger = logging.getLogger(__name__)

--- a/src/core/voices/__init__.py
+++ b/src/core/voices/__init__.py
@@ -1,6 +1,5 @@
 """Voice system for newsletter commentary generation."""
 
-from .base import VoiceConfig, VoiceGenerator
 from .saint import SAINT_CONFIG, SAINT_PROMPT_TEMPLATE
 
 # Voice registry

--- a/src/quality_checks/anti_llm_validator.py
+++ b/src/quality_checks/anti_llm_validator.py
@@ -9,7 +9,7 @@ Enforces specific editorial standards and structure requirements.
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Set, Tuple
+from typing import List, Tuple
 
 
 class ValidationLevel(Enum):


### PR DESCRIPTION
## Summary
- remove unused imports and variables flagged by flake8 across cache, newsletter, readwise, and validator modules
- adjust newsletter logging calls to avoid f-string placeholder issues
- clean voice manager registry exports to keep only referenced objects

## Testing
- `flake8 src/`


@nycterent can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d43c459056d34741b55368ff4621cd1f)